### PR TITLE
Minor cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.nrepl-port
 /checkouts
 /classes
+/converted
 /target
 *.class
 *.jar

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ alias kale="java -jar /full/path/to/kale/target/uberjar/kale-1.3.0-SNAPSHOT-st
 
 ## Licensing
 
-All sample code contained within this project repository or any
+All code contained within this project repository or any
 subdirectories is licensed according to the terms of the MIT license,
 which can be viewed in the file [LICENSE](LICENSE).
 


### PR DESCRIPTION
`kale` is not "sample" code. We intend for `kale` to be directly
useful. Also, git ignore the `converted` directory, which is created
when running tests.
