### PR TITLE
Rename `convert` to `dry_run`

### DIFF
--- a/src/kale/aliases.clj
+++ b/src/kale/aliases.clj
@@ -11,8 +11,8 @@
 (def assemble
   #{"assemble" "a"})
 
-(def convert
-  #{"convert" "conv"})
+(def dry-run
+  #{"dry_run" "dry-run" "dryrun" "dr"})
 
 (def create
   #{"create" "cr"})
@@ -54,7 +54,7 @@
 
 (def commands
   (apply conj (map aliases-to-keyword [:assemble
-                                       :convert
+                                       :dry-run
                                        :create
                                        :delete
                                        :get-command
@@ -78,15 +78,19 @@
 ;; The next two are both used for "select":
 ;; need to avoid collisions or even potential confusions.
 (def document-conversion
-  #{"document-conversion" "document_conversion" "doc" "dc" "d"})
+  #{"document-conversion" "document_conversion"
+    "doc" "dc" "d"})
 
 (def conversion-configuration
-  #{"conversion-configuration" "conversion-config"
-    "converter-configuration" "converter-config"
-    "convert-config"})
+  #{"conversion-configuration" "conversion_configuration"
+    "conversion-config" "conversion_config"
+    "converter-configuration" "converter_configuration"
+    "converter-config" "converter_config"
+    "convert-config" "convert_config"})
 
 (def retrieve-and-rank
-  #{"retrieve-and-rank" "retrieve_and_rank" "retrieve" "ret" "rnr" "r"})
+  #{"retrieve-and-rank" "retrieve_and_rank"
+    "retrieve" "ret" "rnr" "r"})
 
 (def guid-option
   #{"--guid" "-guid"})
@@ -98,13 +102,15 @@
   #{"clu" "clus" "clust" "cluster"})
 
 (def solr-configuration
-  #{"solr-configuration" "solr-config" "configuration" "config" "conf"})
+  #{"solr-configuration" "solr_configuration"
+    "solr-config" "solr_config"
+    "configuration" "config" "conf"})
 
 (def crawler-configuration
-  #{"crawler-configuration"
-    "crawler-config"
-    "crawl-configuration"
-    "crawl-config"
+  #{"crawler-configuration" "crawler_configuration"
+    "crawler-config" "crawler_config"
+    "crawl-configuration" "crawl_configuration"
+    "crawl-config" "crawl_config"
     "cc"})
 
 (def conversion

--- a/src/kale/dry_run.clj
+++ b/src/kale/dry_run.clj
@@ -2,7 +2,7 @@
 ;; (C) Copyright IBM Corp. 2016 All Rights Reserved.
 ;;
 
-(ns kale.convert
+(ns kale.dry-run
   (:require [clojure.java.io :as io]
             [kale.common :refer [fail new-line readable-files?
                                  get-command-msg get-options
@@ -15,7 +15,7 @@
 (defn get-msg
   "Return the corresponding convert message"
    [msg-key & args]
-   (apply get-command-msg :convert-messages msg-key args))
+   (apply get-command-msg :dry-run-messages msg-key args))
 
 (defn get-dry-run-config
   "Get the configuration for conversion.
@@ -53,8 +53,8 @@
              (catch Exception e
                  (println (get-msg :invalid-json))))))))
 
-(defn convert
-  "The 'convert' command."
+(defn dry-run
+  "The 'dry_run' command."
   [state [_ & filenames] flags]
   (get-options flags {})
   (if (readable-files? filenames)

--- a/src/kale/main.clj
+++ b/src/kale/main.clj
@@ -8,7 +8,7 @@
             [kale.common :refer [fail try-function get-command-msg
                                  set-trace set-language]]
             [kale.assemble]
-            [kale.convert]
+            [kale.dry-run]
             [kale.create]
             [kale.delete]
             [kale.persistence]
@@ -63,7 +63,7 @@
 (def verbs
   "Our supported verbs and the functions implementing each"
   {:assemble       kale.assemble/assemble
-   :convert        kale.convert/convert
+   :dry-run        kale.dry-run/dry-run
    :create         kale.create/create
    :delete         kale.delete/delete
    :get-command    kale.get-command/get-command

--- a/src/kale/messages/en.clj
+++ b/src/kale/messages/en.clj
@@ -64,7 +64,7 @@ Commands:
     kale refresh
     kale assemble <name> english|german|spanish
     kale get solr-configuration <name>
-    kale convert <file>
+    kale dry_run <file>
     kale search <query>
 
 Help on individual commands can be found by running:
@@ -247,22 +247,23 @@ can also be selected.
     kale select conversion-configuration <file.json>
 "
 
-     :convert
-"Convert one or more files through the Document Conversion service.
-The conversion is done via the 'dry_run' option to the 'index_document'
-API of the Document Conversion service.  This meant to test how files
-will be converted before running the Data Crawler.
+     :dry-run
+"Dry run of conversion for one or more files through the Document
+Conversion service. The conversion is done via the 'dry_run' option to
+the 'index_document' API of the Document Conversion service. 'dry_run'
+is used to test how files will be converted before running the Data
+Crawler to upload, convert and index large volumes of documents.
 
 The converted files will be placed in the 'converted' directory
 under your current working directory.
 
-    kale convert reliability-study.doc
+    kale dry_run reliability-study.doc
 
 Will create a converted file: 'converted/reliability-study.doc.json'
 
 Multiple files can be converted via:
 
-    kale convert fileA.doc fileB.doc ...
+    kale dry_run fileA.doc fileB.doc ...
 "
 
      :refresh
@@ -683,8 +684,8 @@ these services will be provisioned using the 'standard' plan.
      :unknown-config "A Solr configuration named '%s' does not exist."
      :saved-config "Configuration saved into '%s.zip'."}
 
-  :convert-messages
-    {:empty-config "Warning: Using an empty configuration: \"{}\"."
+  :dry-run-messages
+    {:empty-config "Note: Using the default conversion configuration: \"{}\"."
      :converting "Converting '%s' ..."
      :conversion-failed "Conversion failed for '%s':"
      :completed " completed."

--- a/test/kale/aliases_test.clj
+++ b/test/kale/aliases_test.clj
@@ -8,7 +8,7 @@
 
 (def alias-count-for-commands
   (apply + (map count [sut/assemble
-                       sut/convert
+                       sut/dry-run
                        sut/create
                        sut/delete
                        sut/get-command


### PR DESCRIPTION
Also, add aliases to allow users to type dash "-" or underscore "_" in
most contexts.
