### PR TITLE
Pick up the project version at compile time

### DIFF
--- a/src/kale/messages/en.clj
+++ b/src/kale/messages/en.clj
@@ -17,7 +17,7 @@
 ██╔═██╗ ██╔══██║██║     ██╔══╝
 ██║  ██╗██║  ██║███████╗███████╗
 ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝
-" (kale-version) "
+Version " (kale-version) "
 
 The command line administration tool for Enhanced Information
 Retrieval.

--- a/src/kale/messages/en.clj
+++ b/src/kale/messages/en.clj
@@ -2,22 +2,22 @@
 ;; (C) Copyright IBM Corp. 2016 All Rights Reserved.
 ;;
 
-(ns kale.messages.en)
+(ns kale.messages.en
+  (:require [kale.version :refer [kale-version]]))
 
 (def ^:const new-line (System/getProperty "line.separator"))
 
 (def messages
   "English output text, keyed by area."
   {:help-messages
-    {:help
-"
+   {:help (str "
 ██╗  ██╗ █████╗ ██╗     ███████╗
 ██║ ██╔╝██╔══██╗██║     ██╔════╝
 █████╔╝ ███████║██║     █████╗
 ██╔═██╗ ██╔══██║██║     ██╔══╝
 ██║  ██╗██║  ██║███████╗███████╗
 ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝
-Version 1.5.0-SNAPSHOT
+" (kale-version) "
 
 The command line administration tool for Enhanced Information
 Retrieval.
@@ -74,7 +74,7 @@ There are two global options for each command:
   --trace   Output logging for any API calls made to Bluemix and
             Watson services.
   --help    Retrieve help information on the specified command.
-"
+")
 
      :login
 "The 'login' command connects the user to Bluemix and starts a

--- a/src/kale/version.clj
+++ b/src/kale/version.clj
@@ -1,0 +1,7 @@
+(ns kale.version)
+
+;; This is a little weird. Leiningen gives us a Java System property
+;; with our version number _at_compile_time_.
+
+;; The unquote ~ here causes the getProperty to be evaluated at compile time.
+(defmacro kale-version [] `~(System/getProperty "kale.version"))


### PR DESCRIPTION
This becomes more important when we report a version in our User-Agent header.
