### PR TITLE
Add "retry" to some create commands

### DIFF
--- a/src/kale/aliases.clj
+++ b/src/kale/aliases.clj
@@ -144,6 +144,9 @@
 (def wait-option
   #{"--wait" "-wait" "-w"})
 
+(def retry-option
+  #{"--retry" "-retry" "-r"})
+
 (def yes-option
   #{"--yes" "-yes" "--y" "-y"})
 

--- a/src/kale/messages/en.clj
+++ b/src/kale/messages/en.clj
@@ -474,6 +474,8 @@ these services will be provisioned using the 'standard' plan.
           new-line "Please create a Solr cluster or select "
                    "an existing one.")
      :creating-config "Creating configuration '%s' in '%s/%s'."
+     :retry-config
+     "Creating configuration failed with a 'not found' error. Retrying..."
      :config-created  (str "Solr configuration named '%s' has been created "
                            "and selected for future actions.")
 
@@ -488,6 +490,8 @@ these services will be provisioned using the 'standard' plan.
           "Please upload a Solr configuration or select an existing one.")
      :creating-collection
      "Creating collection '%s' in '%s/%s' using config '%s'."
+     :retry-collection
+     "Creating collection failed with a 'not found' error. Retrying..."
      :collection-created (str "Collection '%s' has been created"
                               " and selected for future actions.")
 

--- a/test/kale/assemble_test.clj
+++ b/test/kale/assemble_test.clj
@@ -85,8 +85,8 @@
        "[Running command 'kale create retrieve_and_rank turtle-rnr']" new-line
        "[Running command 'kale create cluster turtle-cluster --wait']" new-line
        "[Running command 'kale create solr-configuration " create-config-args
-       "']" new-line
-       "[Running command 'kale create collection turtle-collection']"
+       " --retry']" new-line
+       "[Running command 'kale create collection turtle-collection --retry']"
        new-line))
 
 (deftest assemble-prepackaged-config


### PR DESCRIPTION
Note that this doesn't actually work 😢 

```
Creating configuration 'english' in 'ford-rnr/joe'.
Creating configuration failed with a 'not found' error. Retrying...
Creating configuration 'english' in 'ford-rnr/joe'.
Jun 10, 2016 3:18:22 PM org.apache.http.impl.client.DefaultHttpClient tryExecute
INFO: I/O exception (java.io.IOException) caught when processing request to {s}->https://gateway.watsonplatform.net:443: Stream closed
Jun 10, 2016 3:18:22 PM org.apache.http.impl.client.DefaultHttpClient tryExecute
INFO: Retrying request to {s}->https://gateway.watsonplatform.net:443
A call to: https://gateway.watsonplatform.net/retrieve-and-rank/api
triggered an unexpected exception:
java.io.IOException: Stream closed)
```
