### PR TITLE
Improved login behavior

### DIFF
--- a/src/kale/login.clj
+++ b/src/kale/login.clj
@@ -147,8 +147,8 @@
                    (get-password))
         prev-endpoint? (= endpoint (-> state :login :endpoint))
         prev-username? (if (nil? (options :sso))
-                         (= username (-> state :login :username)
-                         true))
+                         (= username (-> state :login :username))
+                         true)
 
         {:keys [access_token]} (if (some? (options :sso))
                                  (cf/get-oauth-tokens-sso endpoint)

--- a/src/kale/login.clj
+++ b/src/kale/login.clj
@@ -82,6 +82,8 @@
         ;; This assumes the user hasn't changed the name of their local org
         default (or (cf/find-entity orgs username)
                     (first orgs))]
+    (when (nil? default)
+      (fail (get-msg :no-orgs-in-region)))
     (or attempt
         (do (if org-name
               (println (get-msg :alternative-org
@@ -97,6 +99,8 @@
   (let [spaces (cf/get-spaces cf-auth org-guid)
         attempt (cf/find-entity spaces space-name)
         default (first spaces)]
+    (when (nil? default)
+      (fail (get-msg :no-spaces-in-org)))
     (or attempt
         (do (if space-name
               (println (get-msg :alternative-space

--- a/src/kale/messages/en.clj
+++ b/src/kale/messages/en.clj
@@ -418,6 +418,10 @@ these services will be provisioned using the 'standard' plan.
      :using-password "Using password from environment variable 'KALE_PASSWORD'"
      :prompt-password "Password? "
 
+     :no-orgs-in-region
+     "Unable to find any available orgs for the given endpoint."
+     :no-spaces-in-org
+     "Unable to find any available spaces for the org."
      :alternative-org "Unable to find org '%s', using org '%s' instead"
      :using-org "Using org '%s'"
      :alternative-space "Unable to find space '%s', using space '%s' instead"

--- a/test/kale/login_test.clj
+++ b/test/kale/login_test.clj
@@ -146,6 +146,13 @@
                                                 "bad-org"
                                                 "redshirt"))))))))
 
+(t/deftest no-available-orgs
+  (with-redefs [cf/get-organizations (fn [_] [])]
+    (t/is (thrown+-with-msg?
+         [:type :kale.common/fail]
+         #"Unable to find any available orgs for the given endpoint."
+         (sut/attempt-to-get-org cf-auth "bad-org" "redshirt")))))
+
 (t/deftest get-existing-space
   (with-fake-routes-in-isolation
     {(cf-url "/v2/organizations/ORG_GUID/spaces")
@@ -173,6 +180,13 @@
                (t/is (= (space-entity "SPACE_GUID1" "space1")
                         (sut/attempt-to-get-space
                          cf-auth "ORG_GUID" "bad-space"))))))))
+
+(t/deftest no-available-spaces
+  (with-redefs [cf/get-spaces (fn [_ _] [])]
+    (t/is (thrown+-with-msg?
+         [:type :kale.common/fail]
+         #"Unable to find any available spaces for the org."
+         (sut/attempt-to-get-space cf-auth "ORG_GUID" "bad-space")))))
 
 (t/deftest get-org-space
   (with-redefs [sut/attempt-to-get-org


### PR DESCRIPTION
This commit fixes a bug where we don't correctly use the user's default org and space during login.  It also provides some meaningful error messages if kale tries to log into a region with no orgs or an org with no spaces.
