### PR TITLE
Reduce concurrent_upload_connection_limit from 100 to 14

### DIFF
--- a/src/kale/create.clj
+++ b/src/kale/create.clj
@@ -299,7 +299,7 @@
         {:keys [url username password]}
         (get-in conversion-service [1 :credentials])]
     {:base_url url
-     :concurrent_upload_connection_limit 100
+     :concurrent_upload_connection_limit 14
      :config_file "orchestration_service_config.json"
      :credentials {:username username :password password}
      :endpoint (str "/v1/index_document?version=" version)

--- a/test/kale/create_test.clj
+++ b/test/kale/create_test.clj
@@ -518,7 +518,7 @@
 
   (is (= (str "{" new-line
               "  \"base_url\" : null," new-line
-              "  \"concurrent_upload_connection_limit\" : 100," new-line
+              "  \"concurrent_upload_connection_limit\" : 14," new-line
               "  \"config_file\" : \"orchestration_service_config.json\","
               new-line
               "  \"credentials\" : {" new-line


### PR DESCRIPTION
A change in the service necessitated a limit of 14 connections per user. 

Exceeding this will cause 429 errors and inevitable retry failures, because backoff won't be sufficient to allow connections to finish.
