### PR TITLE
Switch from clj-http to http-kit

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
   :target-path "target/%s"
   :prep-tasks [["exec" "solr/package.clj"]
                "compile"]
-  :profiles {:dev {:dependencies [[http-kit.fake "0.2.1"]]
+  :profiles {:dev {:dependencies [[http-kit.fake "0.2.2"]]
                    :plugins [[jonase/eastwood "0.2.3"
                               :exclusions [org.clojure/clojure]]
                              [lein-bikeshed "0.3.0"

--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,8 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.codec "0.1.0"]
                  [cheshire "5.5.0"]
-                 [clj-http "2.1.0"]
                  [clj-time "0.11.0"]
+                 [http-kit "2.2.0"]
                  [slingshot "0.12.2"]
                  ;; Not a direct dependency.
                  ;; This is here to lock in a specific version.
@@ -20,7 +20,7 @@
   :target-path "target/%s"
   :prep-tasks [["exec" "solr/package.clj"]
                "compile"]
-  :profiles {:dev {:dependencies [[clj-http-fake "1.0.2"]]
+  :profiles {:dev {:dependencies [[http-kit.fake "0.2.1"]]
                    :plugins [[jonase/eastwood "0.2.3"
                               :exclusions [org.clojure/clojure]]
                              [lein-bikeshed "0.3.0"

--- a/src/kale/dry_run.clj
+++ b/src/kale/dry_run.clj
@@ -40,9 +40,10 @@
                       (dc/convert endpoint version config (io/file in-file))
                       (catch Exception e
                         ;; Notice that we continue processing after this
-                        (println (str new-line
-                                      (get-msg :conversion-failed in-file)
-                                      new-line (:body (ex-data e))))))]
+                        (let [{:keys [error body]} (ex-data e)]
+                          (println (str new-line
+                                        (get-msg :conversion-failed in-file)
+                                        new-line (or error body))))))]
       (when converted
         (spit output-file converted)
         (try (let [{:keys [warnings]} (json/decode converted true)]

--- a/src/kale/messages/en.clj
+++ b/src/kale/messages/en.clj
@@ -381,8 +381,8 @@ these services will be provisioned using the 'standard' plan.
 
   :common-messages
     {:unknown-language "Language '%s' is not available."
-     :http-call "A call to: %s"
-     :http-exception "triggered an unexpected exception:"
+     :http-call "A %s to: %s"
+     :http-exception "triggered an unexpected exception: %s"
      :http-error-status "returned an unexpected error status code %s"
      :other-exception (str "Something unexpected failed while trying to "
                            "process your command. This exception was thrown:")

--- a/src/kale/watson_service.clj
+++ b/src/kale/watson_service.clj
@@ -71,9 +71,14 @@
                                :user-agent user-agent-string
                                :url url} options)
                authorization (generate-auth username password token)
-               response @(client/request (merge request authorization))]
-
+               {:keys [error status] :as response} @(client/request
+                                              (merge request authorization))]
            (when @trace-enabled (trace-api request response))
+           (when (or error
+                     (not (#{200 201 202 203 204 205 206 207
+                             300 301 302 303 307}
+                           status)))
+             (throw+ response))
            response)
          ;; Only intercept unexpected exceptions here
          (catch (not (number? (:status %))) e

--- a/src/kale/watson_service.clj
+++ b/src/kale/watson_service.clj
@@ -29,8 +29,8 @@
 
 (defn get-msg
   "Return the corresponding service message"
-   [msg-key & args]
-   (apply get-command-msg :service-messages msg-key args))
+  [msg-key & args]
+  (apply get-command-msg :service-messages msg-key args))
 
 (defn setup-multipart
   "Expands a simple hashmap of name:value pairs into
@@ -51,13 +51,13 @@
   (println (get-msg :trace-request))
   (pprint request)
   (println (get-msg :trace-response))
-  (if (some? (response :body))
-    (let [content-type ((response :headers) "Content-Type")]
+  (if (some? (:body response))
+    (if-let [content-type (:content-type (:headers response))]
       (cond
         (some? (re-find #"zip" content-type))
-          (pprint (assoc response :body (get-msg :trace-zip-content)))
+        (pprint (assoc response :body (get-msg :trace-zip-content)))
         (some? (re-find #"json" content-type))
-          (pprint (update-in response [:body] json/decode true))
+        (pprint (update-in response [:body] json/decode true))
         :else (pprint response)))
     (pprint response)))
 
@@ -65,20 +65,29 @@
   "Raw HTTP request."
   ([method endpoint] (raw method endpoint "" {}))
   ([method endpoint path] (raw method endpoint path {}))
-  ([method {:keys [url username password token]} path options]
+  ([method
+    {:keys [url username password token]}
+    path
+    {:keys [content-type] :as options}]
    (try+ (let [url (str url path)
-               request (merge {:method method
-                               :user-agent user-agent-string
-                               :url url} options)
+               request (merge
+                        {:method method
+                         :user-agent user-agent-string
+                         :url url}
+                        options
+                        (and
+                         content-type
+                         {:headers {"Content-Type"
+                                    (str "application/" (name content-type))}}))
                authorization (generate-auth username password token)
-               {:keys [error status] :as response} @(client/request
-                                              (merge request authorization))]
+               {:keys [error status]
+                :as response} @(client/request
+                                (merge request authorization))]
            (when @trace-enabled (trace-api request response))
-           (when (or error
-                     (not (#{200 201 202 203 204 205 206 207
-                             300 301 302 303 307}
-                           status)))
-             (throw+ response))
+           (when (not (#{200 201 202 203 204 205 206 207
+                         300 301 302 303 307}
+                       status))
+             (throw+ (merge {:status -2} response)))
            response)
          ;; Only intercept unexpected exceptions here
          (catch (not (number? (:status %))) e
@@ -87,7 +96,8 @@
            ;; message to the end user.
            (throw+ {:body (str e)
                     :status -1
-                    :trace-redirects [url]})))))
+                    :opts {:method method
+                           :url url}})))))
 
 (defn text
   "HTTP request, returning just the body of the response as a string."

--- a/src/kale/watson_service.clj
+++ b/src/kale/watson_service.clj
@@ -7,7 +7,7 @@
             [kale.version :refer [kale-version]]
             [clojure.pprint :refer [pprint]]
             [cheshire.core :as json]
-            [clj-http.client :as client]
+            [org.httpkit.client :as client]
             [slingshot.slingshot :refer [throw+ try+]]
             [clojure.string :as str]))
 
@@ -68,10 +68,10 @@
   ([method {:keys [url username password token]} path options]
    (try+ (let [url (str url path)
                request (merge {:method method
-                               :headers user-agent-header
+                               :user-agent user-agent-string
                                :url url} options)
                authorization (generate-auth username password token)
-               response (client/request (merge request authorization))]
+               response @(client/request (merge request authorization))]
 
            (when @trace-enabled (trace-api request response))
            response)

--- a/test/kale/cloud_foundry_constants.clj
+++ b/test/kale/cloud_foundry_constants.clj
@@ -191,7 +191,7 @@
 
 (defn respond
   [partial-response]
-  (fn [request] (merge template-response partial-response)))
+  (merge template-response partial-response))
 
 (def cf-auth
   {:url "https://api.ng.bluemix.net"

--- a/test/kale/create_test.clj
+++ b/test/kale/create_test.clj
@@ -9,7 +9,7 @@
             [kale.cloud-foundry-constants :as c]
             [cheshire.core :as json]
             [clj-time.core :refer [in-minutes]]
-            [clj-http.fake :refer [with-fake-routes-in-isolation]]
+            [org.httpkit.fake :refer [with-fake-http]]
             [kale.common :refer [new-line] :as common]
             [clojure.test :refer [deftest is]]
             [slingshot.test :refer :all]
@@ -106,9 +106,9 @@
   (c/service-key-entity "GUID" "retrieve_and_rank"))
 
 (deftest create-service-with-existing-plan
-  (with-fake-routes-in-isolation
-    {(c/cf-url "/v2/service_instances?accepts_incomplete=true")
-     (c/respond {:body (json/encode service-instance)})}
+  (with-fake-http
+    [(c/cf-url "/v2/service_instances?accepts_incomplete=true")
+     (c/respond {:body (json/encode service-instance)})]
     (with-redefs [cf/get-service-plan-guid (fn [_ _ _ _] "PLAN_GUID")]
       (is (= (str "Creating retrieve_and_rank service 'new-service' "
                   "using the 'standard' plan." new-line)
@@ -130,9 +130,9 @@
                   "new-service" "premium")))))
 
 (deftest create-key-for-service
-  (with-fake-routes-in-isolation
-    {(c/cf-url "/v2/service_keys")
-     (c/respond {:body (json/encode service-key)})}
+  (with-fake-http
+    [(c/cf-url "/v2/service_keys")
+     (c/respond {:body (json/encode service-key)})]
     (is (= (str "Creating key for service 'some-service'." new-line)
            (with-out-str
              (is (= service-key

--- a/test/kale/document_conversion_test.clj
+++ b/test/kale/document_conversion_test.clj
@@ -5,8 +5,9 @@
 (ns kale.document-conversion-test
   (:require [kale.document-conversion :as dc]
             [kale.common :refer [set-language]]
-            [clj-http.fake :refer [with-fake-routes-in-isolation]]
-            [clojure.test :refer :all]))
+            [org.httpkit.fake :refer [with-fake-http]]
+            [clojure.test :refer :all]
+            [slingshot.test :refer :all]))
 
 (set-language :en)
 
@@ -41,12 +42,12 @@
 
 (defn respond
   [partial-response]
-  (fn [request] (merge template-response partial-response)))
+  (merge template-response partial-response))
 
 (deftest happy-path
-  (with-fake-routes-in-isolation
-    {(dc-url "2016-03-15")
-     (respond {:body "Converted document"})}
+  (with-fake-http
+    [(dc-url "2016-03-15")
+     (respond {:body "Converted document"})]
     (is (= "Converted document"
            (dc/convert endpoint
                        "2016-03-15"

--- a/test/kale/dry_run_test.clj
+++ b/test/kale/dry_run_test.clj
@@ -7,7 +7,6 @@
             [kale.common :refer [new-line set-language]]
             [kale.document-conversion :as dc]
             [slingshot.test :refer :all]
-            [clj-http.fake :refer [with-fake-routes-in-isolation]]
             [kale.dry-run :as sut]))
 
 (set-language :en)
@@ -94,21 +93,3 @@
                     (do (sut/dry-run {}
                                      ["dry-run" "test-file.html"] [])
                         (slurp "converted/test-file.html.json")))))))))
-
-(deftest dry-run-failure
-  (is (= (str "Note: Using the default conversion configuration: \"{}\"."
-              new-line
-              "Converting 'test-file.html' ..." new-line
-              "Conversion failed for 'test-file.html':"
-              new-line
-              "java.net.MalformedURLException:"
-              " no protocol: /v1/index_document?version=2016-03-18"
-              new-line)
-         (with-out-str
-           (is (= (str new-line "Conversion completed."
-                       " Please find the converted output"
-                       " in the directory 'converted'." new-line)
-                  (sut/dry-run {:services {:dc {:type "document_conversion"
-                                                :credentials {}}}}
-                               ["dry-run" "test-file.html"]
-                               [])))))))

--- a/test/kale/dry_run_test.clj
+++ b/test/kale/dry_run_test.clj
@@ -93,3 +93,21 @@
                     (do (sut/dry-run {}
                                      ["dry-run" "test-file.html"] [])
                         (slurp "converted/test-file.html.json")))))))))
+
+(deftest dry-run-failure
+  (is (= (str "Note: Using the default conversion configuration: \"{}\"."
+              new-line
+              "Converting 'test-file.html' ..." new-line
+              "Conversion failed for 'test-file.html':"
+              new-line
+              "java.lang.IllegalArgumentException:"
+              " host is null: /v1/index_document?version=2016-03-18"
+              new-line)
+         (with-out-str
+           (is (= (str new-line "Conversion completed."
+                       " Please find the converted output"
+                       " in the directory 'converted'." new-line)
+                  (sut/dry-run {:services {:dc {:type "document_conversion"
+                                                :credentials {}}}}
+                               ["dry-run" "test-file.html"]
+                               [])))))))

--- a/test/kale/login_test.clj
+++ b/test/kale/login_test.clj
@@ -9,7 +9,7 @@
             [kale.common :refer [new-line] :as common]
             [kale.cloud-foundry-constants :refer :all]
             [clojure.test :as t]
-            [clj-http.fake :refer [with-fake-routes-in-isolation]]
+            [org.httpkit.fake :refer [with-fake-http]]
             [cheshire.core :as json]
             [slingshot.test :refer :all]))
 
@@ -110,34 +110,34 @@
     (t/is (= "scotty" (sut/get-password)))))
 
 (t/deftest get-existing-org
-  (with-fake-routes-in-isolation
-    {(cf-url "/v2/organizations")
-     (respond {:body (json/encode orgs-response)})}
+  (with-fake-http
+    [(cf-url "/v2/organizations")
+     (respond {:body (json/encode orgs-response)})]
     (t/is (= (org-entity "ORG_GUID1" "org1")
              (sut/attempt-to-get-org cf-auth "org1" "redshirt")))))
 
 (t/deftest get-local-org
-  (with-fake-routes-in-isolation
-    {(cf-url "/v2/organizations")
-     (respond {:body (json/encode orgs-response)})}
+  (with-fake-http
+    [(cf-url "/v2/organizations")
+     (respond {:body (json/encode orgs-response)})]
     (t/is (= (str "Using org 'org2'" new-line)
              (with-out-str
                (t/is (= (org-entity "ORG_GUID2" "org2")
                         (sut/attempt-to-get-org cf-auth nil "org2"))))))))
 
 (t/deftest attempt-nil-org
-  (with-fake-routes-in-isolation
-    {(cf-url "/v2/organizations")
-     (respond {:body (json/encode orgs-response)})}
+  (with-fake-http
+    [(cf-url "/v2/organizations")
+     (respond {:body (json/encode orgs-response)})]
     (t/is (= (str "Using org 'org1'" new-line)
              (with-out-str
                (t/is (= (org-entity "ORG_GUID1" "org1")
                         (sut/attempt-to-get-org cf-auth nil "redshirt"))))))))
 
 (t/deftest attempt-bad-org
-  (with-fake-routes-in-isolation
-    {(cf-url "/v2/organizations")
-     (respond {:body (json/encode orgs-response)})}
+  (with-fake-http
+    [(cf-url "/v2/organizations")
+     (respond {:body (json/encode orgs-response)})]
     (t/is (= (str "Unable to find org 'bad-org', using org 'org1' instead"
                   new-line)
              (with-out-str
@@ -154,25 +154,25 @@
          (sut/attempt-to-get-org cf-auth "bad-org" "redshirt")))))
 
 (t/deftest get-existing-space
-  (with-fake-routes-in-isolation
-    {(cf-url "/v2/organizations/ORG_GUID/spaces")
-     (respond {:body (json/encode spaces-response)})}
+  (with-fake-http
+    [(cf-url "/v2/organizations/ORG_GUID/spaces")
+     (respond {:body (json/encode spaces-response)})]
     (t/is (= (space-entity "SPACE_GUID1" "space1")
              (sut/attempt-to-get-space cf-auth "ORG_GUID" "space1")))))
 
 (t/deftest attempt-nil-space
-  (with-fake-routes-in-isolation
-    {(cf-url "/v2/organizations/ORG_GUID/spaces")
-     (respond {:body (json/encode spaces-response)})}
+  (with-fake-http
+    [(cf-url "/v2/organizations/ORG_GUID/spaces")
+     (respond {:body (json/encode spaces-response)})]
     (t/is (= (str "Using space 'space1'" new-line)
              (with-out-str
                (t/is (= (space-entity "SPACE_GUID1" "space1")
                         (sut/attempt-to-get-space cf-auth "ORG_GUID" nil))))))))
 
 (t/deftest attempt-bad-space
-  (with-fake-routes-in-isolation
-    {(cf-url "/v2/organizations/ORG_GUID/spaces")
-     (respond {:body (json/encode spaces-response)})}
+  (with-fake-http
+    [(cf-url "/v2/organizations/ORG_GUID/spaces")
+     (respond {:body (json/encode spaces-response)})]
     (t/is (= (str
               "Unable to find space 'bad-space', using space 'space1' instead"
               new-line)

--- a/test/kale/main_test.clj
+++ b/test/kale/main_test.clj
@@ -14,8 +14,8 @@
 (common/set-language :en)
 
 (defn get-help-msg
-   [msg-key & vals]
-   (apply common/get-command-msg :help-messages msg-key vals))
+  [msg-key & vals]
+  (apply common/get-command-msg :help-messages msg-key vals))
 
 (deftest read-flags-empty
   (is (= {:args (empty '())
@@ -57,11 +57,11 @@
   (let [lang-key (atom :en)]
     (with-redefs [kale.persistence/read-state (fn []
                                                 {:user-selections
-                                                  {:language "jk"}})
+                                                 {:language "jk"}})
                   common/set-language (fn [new-key]
                                         (reset! lang-key new-key))]
-    (with-out-str (sut/-main "help"))
-    (is (= @lang-key :jk)))))
+      (with-out-str (sut/-main "help"))
+      (is (= @lang-key :jk)))))
 
 (deftest set-help-flag
   (is (= (str (get-help-msg :create) new-line)
@@ -98,13 +98,14 @@
   (with-redefs [commands (fn [_] :nothing)
                 read-state (fn [] {:services {}})
                 verbs {:nothing
-                       (fn [_ _ _] (throw+
-                                  {:status 401
-                                   :body "something broke"
-                                   :trace-redirects
-                                   ["https://api.endpoint.net/v1/info"]}))}
+                       (fn [_ _ _]
+                         (throw+
+                          {:status 401
+                           :body "something broke"
+                           :opts {:method :head
+                                  :url "https://api.endpoint.net/v1/info"}}))}
                 error-exit (fn [])]
-    (is (= (str "A call to: https://api.endpoint.net/v1/info" new-line
+    (is (= (str "A HEAD to: https://api.endpoint.net/v1/info" new-line
                 "returned an unexpected error status code 401" new-line
                 "something broke" new-line)
            (with-out-str (sut/-main "action"))))))
@@ -115,13 +116,14 @@
     (with-redefs [commands (fn [_] :nothing)
                   read-state (fn [] {:services {}})
                   verbs {:nothing
-                         (fn [_ _ _] (throw+
-                                      {:status 401
-                                       :body byte-body
-                                       :trace-redirects
-                                       ["https://api.endpoint.net/v1/info"]}))}
+                         (fn [_ _ _]
+                           (throw+
+                            {:status 401
+                             :body byte-body
+                             :opts {:method :head
+                                    :url "https://api.endpoint.net/v1/info"}}))}
                   error-exit (fn [])]
-      (is (= (str "A call to: https://api.endpoint.net/v1/info" new-line
+      (is (= (str "A HEAD to: https://api.endpoint.net/v1/info" new-line
                   "returned an unexpected error status code 401" new-line
                   "something broke" new-line)
              (with-out-str (sut/-main "action")))))))

--- a/test/kale/watson_service_test.clj
+++ b/test/kale/watson_service_test.clj
@@ -56,13 +56,13 @@
               " :url \"https://example.com/api\"}" new-line
               "RESPONSE:" new-line
               "{:status 200," new-line
-              " :headers {\"Content-Type\" \"application/json\"}," new-line
+              " :headers {:content-type \"application/json\"}," new-line
               " :body {:key \"value\"}}" new-line)
          (with-out-str
            (sut/trace-api {:method :get
-                             :url "https://example.com/api"}
+                           :url "https://example.com/api"}
                           {:status 200
-                           :headers {"Content-Type" "application/json"}
+                           :headers {:content-type "application/json"}
                            :body "{\"key\" : \"value\"}"})))))
 
 (deftest trace-api-text-body
@@ -71,13 +71,13 @@
               " :url \"https://example.com/api\"}" new-line
               "RESPONSE:" new-line
               "{:status 200," new-line
-              " :headers {\"Content-Type\" \"application/text\"}," new-line
+              " :headers {:content-type \"application/text\"}," new-line
               " :body \"Body text.\"}" new-line)
          (with-out-str
            (sut/trace-api {:method :get
-                             :url "https://example.com/api"}
+                           :url "https://example.com/api"}
                           {:status 200
-                           :headers {"Content-Type" "application/text"}
+                           :headers {:content-type "application/text"}
                            :body "Body text."})))))
 
 (deftest trace-api-zip-body
@@ -86,13 +86,13 @@
               " :url \"https://example.com/api\"}" new-line
               "RESPONSE:" new-line
               "{:status 200," new-line
-              " :headers {\"Content-Type\" \"application/zip\"}," new-line
+              " :headers {:content-type \"application/zip\"}," new-line
               " :body \"[ZIP CONTENT]\"}" new-line)
          (with-out-str
            (sut/trace-api {:method :get
-                             :url "https://example.com/api"}
+                           :url "https://example.com/api"}
                           {:status 200
-                           :headers {"Content-Type" "application/zip"}
+                           :headers {:content-type "application/zip"}
                            :body "ZIP_BINARY"})))))
 
 (deftest trace-api-no-body
@@ -103,5 +103,5 @@
               "{:status 200}" new-line)
          (with-out-str
            (sut/trace-api {:method :get
-                             :url "https://example.com/api"}
+                           :url "https://example.com/api"}
                           {:status 200})))))


### PR DESCRIPTION
This fixes #17 by removing the dependency on Apache HttpClient which does not play well with IBM Java and TLS 1.2. Also, reducing our dependencies shrinks the size of our standalone jar by about a quarter, from 7.8Meg to 5.7M.
